### PR TITLE
feat: initial cluster bootstrap module, semantic release workflows

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,0 +1,14 @@
+name: Pull Request
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '*.tf'
+jobs:
+  conventional-commits-pr:
+    if: "github.event.pull_request.draft == false"
+    name: Validate Conventional Commits PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: catalystsquad/action-validate-conventional-commits-pr@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,17 @@
+name: Release
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+    paths:
+      - '*.tf'
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Release
+    steps:
+      - uses: catalystsquad/action-semantic-release-general@v1
+        with:
+          token: ${{ secrets.AUTOMATION_PAT }}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,118 @@
+# deploy prometheus remote write configuration secret
+locals {
+  enable_prometheus_remote_write_secret = (
+    var.prometheus_remote_write_username != "" && var.prometheus_remote_write_password != ""
+  )
+}
+
+resource "kubernetes_namespace_v1" "kube_prometheus_stack" {
+  count = local.enable_prometheus_remote_write_secret && var.manage_kube_prometheus_stack_namespace ? 1 : 0
+  metadata {
+    name = "kube-prometheus-stack"
+  }
+}
+
+resource "kubernetes_secret_v1" "prometheus_remote_write" {
+  count = local.enable_prometheus_remote_write_secret ? 1 : 0
+
+  metadata {
+    name      = var.prometheus_remote_write_secret_name
+    namespace = "kube-prometheus-stack"
+  }
+
+  data = {
+    username = var.prometheus_remote_write_username
+    password = var.prometheus_remote_write_password
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.kube_prometheus_stack
+  ]
+}
+
+# deploy kube-prometheus-stack
+resource "helm_release" "kube_prometheus_stack" {
+  name             = "kube-prometheus-stack"
+  chart            = "kube-prometheus-stack"
+  namespace        = "kube-prometheus-stack"
+  create_namespace = true
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  version          = var.kube_prometheus_stack_chart_version
+  values           = var.kube_prometheus_stack_values
+
+  # disables waiting for all resources to be deployed successfully
+  wait = false
+
+  depends_on = [
+    kubernetes_secret_v1.prometheus_remote_write
+  ]
+}
+
+# deploy argocd
+resource "helm_release" "argo_cd" {
+  name             = "argo-cd"
+  chart            = "argo-cd"
+  namespace        = "argo-cd"
+  create_namespace = true
+  repository       = "https://argoproj.github.io/argo-helm"
+  version          = var.argo_cd_chart_version
+  values           = var.argo_cd_values
+
+  # disables waiting for all resources to be deployed successfully
+  wait = false
+
+  depends_on = [
+    # depend on prometheus so that we can deploy ServiceMonitor custom
+    # resources with the argo_cd helm release
+    helm_release.kube_prometheus_stack
+  ]
+}
+
+# deploy cert manager dns solver secret
+locals {
+  enable_cert_manager_cloudflare_api_token_secret = var.cert_manager_cloudflare_api_token != ""
+}
+
+resource "kubernetes_namespace_v1" "cert_manager" {
+  count = local.enable_cert_manager_cloudflare_api_token_secret && var.manage_cert_manager_namespace ? 1 : 0
+  metadata {
+    name = "cert-manager"
+  }
+}
+
+resource "kubernetes_secret_v1" "cert_manager_cloudflare_api_token" {
+  count = local.enable_cert_manager_cloudflare_api_token_secret ? 1 : 0
+
+  metadata {
+    name      = var.cert_manager_cloudflare_api_token_secret_name
+    namespace = "cert-manager"
+  }
+
+  data = {
+    api-token = var.cert_manager_cloudflare_api_token
+  }
+
+  depends_on = [
+    kubernetes_namespace_v1.cert_manager
+  ]
+}
+
+# deploy platform cluster application
+module "platform_services" {
+  count = var.enable_platform_services ? 1 : 0
+
+  # TODO fix this reference to use terraform registry after initial release
+  source = "github.com/catalystsquad/terraform-k8s-argocd-application"
+
+  name                   = "platform-services"
+  source_chart           = "platform-services"
+  source_repo_url        = "https://raw.githubusercontent.com/catalystsquad/charts/main"
+  source_target_revision = var.platform_services_target_revision
+  helm_values            = var.platform_services_values
+
+  depends_on = [
+    helm_release.argo_cd,
+    kubernetes_secret_v1.prometheus_remote_write,
+    kubernetes_secret_v1.cert_manager_cloudflare_api_token,
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,74 @@
+variable "enable_platform_services" {
+  type    = bool
+  default = false # disabled by default because planning the custom resource requires the crd to exist
+}
+
+variable "platform_services_values" {
+  type    = string
+  default = ""
+}
+
+variable "platform_services_target_revision" {
+  type    = string
+  default = ">=1.0.0-alpha"
+}
+
+variable "kube_prometheus_stack_chart_version" {
+  type    = string
+  default = "33.1.0"
+}
+
+variable "kube_prometheus_stack_values" {
+  type    = list(string)
+  default = []
+}
+
+variable "argo_cd_chart_version" {
+  type    = string
+  default = "3.33.8"
+}
+
+variable "argo_cd_values" {
+  type    = list(string)
+  default = []
+}
+
+variable "prometheus_remote_write_secret_name" {
+  type    = string
+  default = "prometheus-remote-write-basic-auth"
+}
+
+variable "prometheus_remote_write_username" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "prometheus_remote_write_password" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "manage_kube_prometheus_stack_namespace" {
+  description = "Enables management of the kube-prometheus-stack namespace if the remote write secret is being managed"
+  type        = bool
+  default     = true
+}
+
+variable "cert_manager_cloudflare_api_token_secret_name" {
+  type    = string
+  default = "cloudflare-api-token-secret"
+}
+
+variable "cert_manager_cloudflare_api_token" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "manage_cert_manager_namespace" {
+  description = "Enables management of the cert-manager namespace if the cert manager cloudflare api token secret is being managed"
+  type        = bool
+  default     = true
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}


### PR DESCRIPTION
adds the following terraform configuration:
- deploys the kube-prometheus-stack helm chart
- deploys the argo-cd helm chart
- deploys an optional prometheus remotewrite secret
- deploys an optional cert manager cloudflare api token secret 
- deploys an argocd application custom resource for the platform-services helm chart